### PR TITLE
Using TCK Tested JDK builds of OpenJDK

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -12,13 +12,16 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        java-version: [ 11.0.3, 11 ]
     steps:
       - uses: actions/checkout@v2
-      - name: Set up JDK 11
+      - name: Set up JDK ${{ matrix.java-version }}
         uses: actions/setup-java@v2
         with:
-          java-version: '11'
-          distribution: 'adopt'
+          java-version: ${{ matrix.java-version }}
+          distribution: 'zulu'
 
       - name: mvn spring-javaformat:validate
         run: mvn spring-javaformat:validate


### PR DESCRIPTION
The AdoptOpenJDK has been discontinued since July 2021 (https://adoptopenjdk.net). This request is to switch the distribution from 'adopt' to Azul `zulu`. When using Zulu you get all the latest updated (TCK Tested) builds for all versions of OpenJDK even archived fixed versions. 

Also added to the GH Action workflow are fixed (major) release version(s) such as `JDK 11.0.3`. This is often a good practice whenever a build/test triggers (push/pull events) to help determine if the latest (`JDK 11`) had failed the from the **latest build** vs something in **your code** caused (or introduced). 

**For example**, when building with `JDK 11.0.3` (fixed version) the build/tests passes (Green) and JDK 11 fails (Red) will mean that the latest `JDK 11` was the cause and not your code. 

**Note:** Other distributions such as Temurin do not support archived fixed releases prior to Sept. 2021 and many of the non-LTS (long term support) releases if you are planning to try out newer features of the Java language.