### PR TITLE
fix: 修复定时任务分页查询 jobStatus 参数错误

### DIFF
--- a/pig-visual/pig-quartz/src/main/java/com/pig4cloud/pig/daemon/quartz/controller/SysJobController.java
+++ b/pig-visual/pig-quartz/src/main/java/com/pig4cloud/pig/daemon/quartz/controller/SysJobController.java
@@ -81,7 +81,7 @@ public class SysJobController {
 		LambdaQueryWrapper<SysJob> wrapper = Wrappers.<SysJob>lambdaQuery()
 			.like(StrUtil.isNotBlank(sysJob.getJobName()), SysJob::getJobName, sysJob.getJobName())
 			.like(StrUtil.isNotBlank(sysJob.getJobGroup()), SysJob::getJobGroup, sysJob.getJobGroup())
-			.eq(StrUtil.isNotBlank(sysJob.getJobStatus()), SysJob::getJobStatus, sysJob.getJobGroup())
+			.eq(StrUtil.isNotBlank(sysJob.getJobStatus()), SysJob::getJobStatus, sysJob.getJobStatus())
 			.eq(StrUtil.isNotBlank(sysJob.getJobExecuteStatus()), SysJob::getJobExecuteStatus,
 					sysJob.getJobExecuteStatus());
 		return R.ok(sysJobService.page(page, wrapper));


### PR DESCRIPTION
## Summary
- 修复 `SysJobController.getJobPage` 方法中查询条件参数错误

## 问题
第 84 行原代码：
```java
.eq(StrUtil.isNotBlank(sysJob.getJobStatus()), SysJob::getJobStatus, sysJob.getJobGroup())
```
错误地将 `jobGroup` 作为查询参数值，应该是 `jobStatus`。

## 影响
按 `jobStatus` 筛选定时任务时，实际比较的是 `jobGroup` 值，导致查询结果错误。

## 修复
改为正确的参数：
```java
.eq(StrUtil.isNotBlank(sysJob.getJobStatus()), SysJob::getJobStatus, sysJob.getJobStatus())
```