### PR TITLE
fix(register): mark standalone mode key final

### DIFF
--- a/pig-register/src/main/java/com/alibaba/nacos/bootstrap/PigNacosApplication.java
+++ b/pig-register/src/main/java/com/alibaba/nacos/bootstrap/PigNacosApplication.java
@@ -42,7 +42,7 @@ public class PigNacosApplication {
 	/**
 	 * 独立模式系统属性名称
 	 */
-	private static String STANDALONE_MODE = "nacos.standalone";
+	private static final String STANDALONE_MODE = "nacos.standalone";
 
 	public static void main(String[] args) {
 		System.setProperty(STANDALONE_MODE, "true");


### PR DESCRIPTION
## Summary
- Mark pig-register's STANDALONE_MODE system-property key as static final on boot4.
- Keep the existing System.setProperty call site unchanged.

## Verification
- mvn -pl pig-register -DskipTests compile