### PR TITLE
feat(datasource): support disabling config table loading

### DIFF
--- a/pig-common/pig-common-datasource/src/main/java/com/pig4cloud/pig/common/datasource/config/DruidDataSourceProperties.java
+++ b/pig-common/pig-common-datasource/src/main/java/com/pig4cloud/pig/common/datasource/config/DruidDataSourceProperties.java
@@ -39,4 +39,9 @@ public class DruidDataSourceProperties extends DruidConfig {
 	 */
 	private String queryDsSql = "select * from gen_datasource_conf where del_flag = ?";
 
+	/**
+	 * 是否从数据库配置表加载扩展数据源，默认开启
+	 */
+	private Boolean queryDsEnabled = true;
+
 }

--- a/pig-common/pig-common-datasource/src/main/java/com/pig4cloud/pig/common/datasource/config/JdbcDynamicDataSourceProvider.java
+++ b/pig-common/pig-common-datasource/src/main/java/com/pig4cloud/pig/common/datasource/config/JdbcDynamicDataSourceProvider.java
@@ -28,10 +28,12 @@ import com.pig4cloud.pig.common.datasource.util.DsTypeEnum;
 import lombok.extern.slf4j.Slf4j;
 import org.jasypt.encryption.StringEncryptor;
 
+import javax.sql.DataSource;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -56,6 +58,19 @@ public class JdbcDynamicDataSourceProvider extends AbstractJdbcDataSourceProvide
 				properties.getPassword());
 		this.stringEncryptor = stringEncryptor;
 		this.properties = properties;
+	}
+
+	/**
+	 * 加载所有数据源
+	 * @return 所有数据源
+	 */
+	@Override
+	public Map<String, DataSource> loadDataSources() {
+		if (!isQueryDsEnabled()) {
+			log.debug("spring.datasource.druid.query-ds-enabled=false，已关闭数据库配置表加载");
+			return Collections.emptyMap();
+		}
+		return super.loadDataSources();
 	}
 
 	/**
@@ -122,6 +137,14 @@ public class JdbcDynamicDataSourceProvider extends AbstractJdbcDataSourceProvide
 		}
 
 		return map;
+	}
+
+	/**
+	 * 是否开启从数据库配置表加载扩展数据源
+	 * @return true 开启（默认）；仅显式配置为 false 时关闭
+	 */
+	boolean isQueryDsEnabled() {
+		return !Boolean.FALSE.equals(properties.getQueryDsEnabled());
 	}
 
 }

--- a/pig-common/pig-common-datasource/src/test/java/com/pig4cloud/pig/common/datasource/config/JdbcDynamicDataSourceProviderTests.java
+++ b/pig-common/pig-common-datasource/src/test/java/com/pig4cloud/pig/common/datasource/config/JdbcDynamicDataSourceProviderTests.java
@@ -1,0 +1,60 @@
+package com.pig4cloud.pig.common.datasource.config;
+
+import com.baomidou.dynamic.datasource.creator.DefaultDataSourceCreator;
+import org.jasypt.encryption.StringEncryptor;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link JdbcDynamicDataSourceProvider} 单元测试：验证 query-ds-enabled 开关的默认开启与显式关闭行为
+ *
+ * @author lengleng
+ * @date 2026/7/6
+ */
+class JdbcDynamicDataSourceProviderTests {
+
+	@Test
+	void enablesJdbcTableLoadingByDefault() {
+		DruidDataSourceProperties properties = druidProperties();
+		JdbcDynamicDataSourceProvider provider = newProvider(properties);
+
+		assertThat(provider.isQueryDsEnabled()).isTrue();
+	}
+
+	@Test
+	void skipsJdbcTableLoadingWhenDisabledExplicitly() {
+		DruidDataSourceProperties properties = druidProperties();
+		properties.setQueryDsEnabled(false);
+
+		JdbcDynamicDataSourceProvider provider = newProvider(properties);
+
+		assertThat(provider.loadDataSources()).isEmpty();
+		assertThat(provider.isQueryDsEnabled()).isFalse();
+	}
+
+	private static JdbcDynamicDataSourceProvider newProvider(DruidDataSourceProperties properties) {
+		StringEncryptor stringEncryptor = new StringEncryptor() {
+			@Override
+			public String encrypt(String message) {
+				return message;
+			}
+
+			@Override
+			public String decrypt(String encryptedMessage) {
+				return encryptedMessage;
+			}
+		};
+		return new JdbcDynamicDataSourceProvider(new DefaultDataSourceCreator(), stringEncryptor, properties);
+	}
+
+	private static DruidDataSourceProperties druidProperties() {
+		DruidDataSourceProperties properties = new DruidDataSourceProperties();
+		properties.setDriverClassName("not.exists.Driver");
+		properties.setUrl("jdbc:not-executed");
+		properties.setUsername("root");
+		properties.setPassword("root");
+		return properties;
+	}
+
+}


### PR DESCRIPTION
## Summary
- Add `spring.datasource.druid.query-ds-enabled` with default-on behavior.
- Skip JDBC config-table datasource loading when the setting is explicitly `false`.
- Add tests for default enabled and explicit disabled behavior.

## Validation
- `mvn -pl pig-common/pig-common-datasource -am test -DskipTests=false`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new setting to control whether extended data sources are loaded from database configuration.
  * Dynamic data source loading now respects this setting and can be disabled to return no additional sources.

* **Tests**
  * Added coverage for the default enabled behavior and the disabled case to ensure loading is skipped when turned off.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->