### PR TITLE
docs: require Node.js 20.19.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ PIG 提供了完整的部署与开发文档：[wiki.pig4cloud.com](https://wiki.
 - JDK 17+
 - Maven 3.9+
 - Docker 和 Docker Compose
-- Node.js 16+（运行 `pig-ui` 前端时需要）
+- Node.js 20.19.0+（运行 `pig-ui` 前端时需要）
 
 ### 微服务模式
 


### PR DESCRIPTION
## What changed

Updated the root README prerequisites to state that running the `pig-ui` frontend requires Node.js 20.19.0 or newer.

## Why

The previous README still listed Node.js 16+, which no longer matches the frontend runtime requirement.

## Impact

Developers following the backend README will use a compatible Node.js version before starting the frontend.

## Validation

- `git diff --check HEAD~1..HEAD`