### PR TITLE
chore: bump version to 4.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <p align="center">
- <img src="https://img.shields.io/badge/Pig-4.0-success.svg" alt="Pig">
+ <img src="https://img.shields.io/badge/Pig-4.1-success.svg" alt="Pig">
  <img src="https://img.shields.io/badge/Spring%20Cloud-2025.1-blue.svg" alt="Spring Cloud">
  <img src="https://img.shields.io/badge/Spring%20Boot-4.0-blue.svg" alt="Spring Boot">
  <img src="https://img.shields.io/badge/Vue-3.5-blue.svg" alt="Vue">
@@ -59,7 +59,7 @@ docker compose -f docker-compose-boot.yml build && docker compose -f docker-comp
 
 | 依赖 | 版本 |
 | --- | --- |
-| Pig | 4.0.0 |
+| Pig | 4.1.0 |
 | JDK | 17+ |
 | Spring Boot | 4.0.6 |
 | Spring Cloud | 2025.1.2 |

--- a/pig-auth/pom.xml
+++ b/pig-auth/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.pig4cloud</groupId>
         <artifactId>pig</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
     </parent>
 
     <artifactId>pig-auth</artifactId>

--- a/pig-boot/pom.xml
+++ b/pig-boot/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>com.pig4cloud</groupId>
         <artifactId>pig</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
     </parent>
 
     <artifactId>pig-boot</artifactId>

--- a/pig-common/pig-common-bom/pom.xml
+++ b/pig-common/pig-common-bom/pom.xml
@@ -11,7 +11,7 @@
     <description>pig 公共版本控制，在此pom定义的依赖，全局业务微服务不需要指定版本。</description>
 
     <properties>
-        <pig.version>4.0.0</pig.version>
+        <pig.version>4.1.0</pig.version>
         <mybatis-plus.version>3.5.16</mybatis-plus.version>
         <mybatis-spring-boot.version>4.0.1</mybatis-spring-boot.version>
         <mybatis-plus-join.version>1.5.7</mybatis-plus-join.version>

--- a/pig-common/pig-common-core/pom.xml
+++ b/pig-common/pig-common-core/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.pig4cloud</groupId>
         <artifactId>pig-common</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
     </parent>
 
     <artifactId>pig-common-core</artifactId>

--- a/pig-common/pig-common-data/pom.xml
+++ b/pig-common/pig-common-data/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.pig4cloud</groupId>
         <artifactId>pig-common</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
     </parent>
 
     <artifactId>pig-common-data</artifactId>

--- a/pig-common/pig-common-datasource/pom.xml
+++ b/pig-common/pig-common-datasource/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>pig-common</artifactId>
         <groupId>com.pig4cloud</groupId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pig-common/pig-common-excel/pom.xml
+++ b/pig-common/pig-common-excel/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.pig4cloud</groupId>
         <artifactId>pig-common</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
     </parent>
 
     <artifactId>pig-common-excel</artifactId>

--- a/pig-common/pig-common-feign/pom.xml
+++ b/pig-common/pig-common-feign/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pig4cloud</groupId>
         <artifactId>pig-common</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pig-common/pig-common-log/pom.xml
+++ b/pig-common/pig-common-log/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.pig4cloud</groupId>
         <artifactId>pig-common</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
     </parent>
 
     <artifactId>pig-common-log</artifactId>

--- a/pig-common/pig-common-oss/pom.xml
+++ b/pig-common/pig-common-oss/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pig4cloud</groupId>
         <artifactId>pig-common</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
     </parent>
 
     <artifactId>pig-common-oss</artifactId>

--- a/pig-common/pig-common-security/pom.xml
+++ b/pig-common/pig-common-security/pom.xml
@@ -23,7 +23,7 @@
     <parent>
         <groupId>com.pig4cloud</groupId>
         <artifactId>pig-common</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
     </parent>
 
     <artifactId>pig-common-security</artifactId>

--- a/pig-common/pig-common-sentinel/pom.xml
+++ b/pig-common/pig-common-sentinel/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pig4cloud</groupId>
         <artifactId>pig-common</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
     </parent>
 
     <modelVersion>4.0.0</modelVersion>

--- a/pig-common/pig-common-swagger/pom.xml
+++ b/pig-common/pig-common-swagger/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.pig4cloud</groupId>
         <artifactId>pig-common</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
     </parent>
 
     <artifactId>pig-common-swagger</artifactId>

--- a/pig-common/pig-common-xss/pom.xml
+++ b/pig-common/pig-common-xss/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pig4cloud</groupId>
         <artifactId>pig-common</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
     </parent>
 
     <artifactId>pig-common-xss</artifactId>

--- a/pig-common/pom.xml
+++ b/pig-common/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.pig4cloud</groupId>
         <artifactId>pig</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
     </parent>
 
     <artifactId>pig-common</artifactId>

--- a/pig-gateway/pom.xml
+++ b/pig-gateway/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.pig4cloud</groupId>
         <artifactId>pig</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
     </parent>
 
     <artifactId>pig-gateway</artifactId>

--- a/pig-register/pom.xml
+++ b/pig-register/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>com.pig4cloud</groupId>
         <artifactId>pig</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
     </parent>
 
     <artifactId>pig-register</artifactId>

--- a/pig-upms/pig-upms-api/pom.xml
+++ b/pig-upms/pig-upms-api/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.pig4cloud</groupId>
         <artifactId>pig-upms</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
     </parent>
 
     <artifactId>pig-upms-api</artifactId>

--- a/pig-upms/pig-upms-biz/pom.xml
+++ b/pig-upms/pig-upms-biz/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.pig4cloud</groupId>
         <artifactId>pig-upms</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
     </parent>
 
     <artifactId>pig-upms-biz</artifactId>

--- a/pig-upms/pom.xml
+++ b/pig-upms/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.pig4cloud</groupId>
         <artifactId>pig</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
     </parent>
 
     <artifactId>pig-upms</artifactId>

--- a/pig-visual/pig-codegen/pom.xml
+++ b/pig-visual/pig-codegen/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.pig4cloud</groupId>
         <artifactId>pig-visual</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
     </parent>
 
     <artifactId>pig-codegen</artifactId>

--- a/pig-visual/pig-monitor/pom.xml
+++ b/pig-visual/pig-monitor/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.pig4cloud</groupId>
         <artifactId>pig-visual</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
     </parent>
 
     <artifactId>pig-monitor</artifactId>

--- a/pig-visual/pig-quartz/pom.xml
+++ b/pig-visual/pig-quartz/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>com.pig4cloud</groupId>
         <artifactId>pig-visual</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pig-visual/pom.xml
+++ b/pig-visual/pom.xml
@@ -24,7 +24,7 @@
     <parent>
         <groupId>com.pig4cloud</groupId>
         <artifactId>pig</artifactId>
-        <version>4.0.0</version>
+        <version>4.1.0</version>
     </parent>
 
     <artifactId>pig-visual</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -24,7 +24,7 @@
 
     <groupId>com.pig4cloud</groupId>
     <artifactId>pig</artifactId>
-    <version>4.0.0</version>
+    <version>4.1.0</version>
     <name>${project.artifactId}</name>
     <packaging>pom</packaging>
     <organization>


### PR DESCRIPTION
## Summary

- Bump the Pig Maven project and module versions to `4.1.0`.
- Update the shared `pig.version` in `pig-common-bom`.
- Refresh README version badges and the core dependency table.

## Impact

This keeps the backend release metadata and documentation aligned for the `4.1.0` release line.

## Validation

- `mvn -q -DforceStdout help:evaluate -Dexpression=project.version`
- `mvn -q -DforceStdout -pl pig-common/pig-common-bom help:evaluate -Dexpression=pig.version`
- `mvn -q -DskipTests validate`
- `git diff --cached --check`