### PR TITLE
fix(feign): 预热消息转换器避免首次并发请求空列表

### DIFF
--- a/pig-common/pig-common-feign/pom.xml
+++ b/pig-common/pig-common-feign/pom.xml
@@ -18,6 +18,11 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-openfeign</artifactId>
         </dependency>
+        <!-- FeignHttpMessageConverters 构造参数 -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-http-converter</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-jackson2</artifactId>

--- a/pig-common/pig-common-feign/src/main/java/com/pig4cloud/pig/common/feign/PigFeignClientConfiguration.java
+++ b/pig-common/pig-common-feign/src/main/java/com/pig4cloud/pig/common/feign/PigFeignClientConfiguration.java
@@ -1,0 +1,53 @@
+/*
+ *    Copyright (c) 2018-2025, lengleng All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * Neither the name of the pig4cloud.com developer nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * Author: lengleng (wangiegie@gmail.com)
+ */
+
+package com.pig4cloud.pig.common.feign;
+
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.http.converter.autoconfigure.ClientHttpMessageConvertersCustomizer;
+import org.springframework.cloud.openfeign.support.FeignHttpMessageConverters;
+import org.springframework.cloud.openfeign.support.HttpMessageConverterCustomizer;
+import org.springframework.context.annotation.Bean;
+
+/**
+ * PIG Feign 客户端子上下文配置。
+ * <p>
+ * 不加 @Configuration：该类仅通过 defaultConfiguration 注册到 Feign 子上下文，
+ * 避免被 pig-boot 等主上下文组件扫描误引入。
+ *
+ * @author lengleng
+ */
+public class PigFeignClientConfiguration {
+
+	/**
+	 * 构建并预热 Feign 消息转换器。
+	 * @param customizers Spring Boot 客户端转换器定制器
+	 * @param cloudCustomizers Spring Cloud 转换器定制器
+	 * @return 已完成初始化的 FeignHttpMessageConverters
+	 */
+	@Bean
+	public FeignHttpMessageConverters pigFeignHttpMessageConverters(
+			ObjectProvider<ClientHttpMessageConvertersCustomizer> customizers,
+			ObjectProvider<HttpMessageConverterCustomizer> cloudCustomizers) {
+		FeignHttpMessageConverters converters = new FeignHttpMessageConverters(customizers, cloudCustomizers);
+		// OpenFeign 5.0.2 在首次调用 getConverters() 时会先发布空列表再填充内容。
+		// Feign 子上下文创建 Bean 时预热，避免并发首请求读到尚未初始化完成的空列表。
+		converters.getConverters();
+		return converters;
+	}
+
+}

--- a/pig-common/pig-common-feign/src/main/java/com/pig4cloud/pig/common/feign/annotation/EnablePigFeignClients.java
+++ b/pig-common/pig-common-feign/src/main/java/com/pig4cloud/pig/common/feign/annotation/EnablePigFeignClients.java
@@ -17,6 +17,7 @@
 
 package com.pig4cloud.pig.common.feign.annotation;
 
+import com.pig4cloud.pig.common.feign.PigFeignClientConfiguration;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.cloud.openfeign.FeignClientsConfiguration;
 import org.springframework.core.annotation.AliasFor;
@@ -68,11 +69,15 @@ public @interface EnablePigFeignClients {
 	 * A custom <code>@Configuration</code> for all feign clients. Can contain override
 	 * <code>@Bean</code> definition for the pieces that make up the client, for instance
 	 * {@link feign.codec.Decoder}, {@link feign.codec.Encoder}, {@link feign.Contract}.
+	 * <p>
+	 * 注意：显式指定该属性会整体替换默认值，即丢失
+	 * {@link PigFeignClientConfiguration} 的消息转换器预热能力；如需自定义，
+	 * 请把 {@code PigFeignClientConfiguration.class} 一并加入数组。
 	 *
 	 * @see FeignClientsConfiguration for the defaults
 	 */
 	@AliasFor(annotation = EnableFeignClients.class)
-	Class<?>[] defaultConfiguration() default {};
+	Class<?>[] defaultConfiguration() default { PigFeignClientConfiguration.class };
 
 	/**
 	 * List of classes annotated with @FeignClient. If not empty, disables classpath

--- a/pig-common/pig-common-feign/src/test/java/com/pig4cloud/pig/common/feign/PigFeignClientConfigurationTests.java
+++ b/pig-common/pig-common-feign/src/test/java/com/pig4cloud/pig/common/feign/PigFeignClientConfigurationTests.java
@@ -1,0 +1,48 @@
+package com.pig4cloud.pig.common.feign;
+
+import com.pig4cloud.pig.common.feign.annotation.EnablePigFeignClients;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.support.StaticListableBeanFactory;
+import org.springframework.boot.http.converter.autoconfigure.ClientHttpMessageConvertersCustomizer;
+import org.springframework.cloud.openfeign.EnableFeignClients;
+import org.springframework.cloud.openfeign.support.FeignHttpMessageConverters;
+import org.springframework.cloud.openfeign.support.HttpMessageConverterCustomizer;
+import org.springframework.core.annotation.AnnotatedElementUtils;
+import org.springframework.core.annotation.AnnotationAttributes;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PigFeignClientConfigurationTests {
+
+	@EnablePigFeignClients
+	private static class TestApplication {
+	}
+
+	@Test
+	void shouldInitializeConvertersBeforePublishingBean() {
+		AtomicBoolean initialized = new AtomicBoolean();
+		StaticListableBeanFactory clientCustomizerFactory = new StaticListableBeanFactory();
+		clientCustomizerFactory.addBean("initializationProbe",
+				(ClientHttpMessageConvertersCustomizer) builder -> initialized.set(true));
+		StaticListableBeanFactory cloudCustomizerFactory = new StaticListableBeanFactory();
+
+		FeignHttpMessageConverters converters = new PigFeignClientConfiguration().pigFeignHttpMessageConverters(
+				clientCustomizerFactory.getBeanProvider(ClientHttpMessageConvertersCustomizer.class),
+				cloudCustomizerFactory.getBeanProvider(HttpMessageConverterCustomizer.class));
+
+		assertThat(initialized).isTrue();
+		assertThat(converters.getConverters()).isNotEmpty();
+	}
+
+	@Test
+	void shouldRegisterWarmupConfigurationForAllFeignClients() {
+		AnnotationAttributes attributes = AnnotatedElementUtils.getMergedAnnotationAttributes(TestApplication.class,
+				EnableFeignClients.class);
+
+		assertThat(attributes).isNotNull();
+		assertThat(attributes.getClassArray("defaultConfiguration")).contains(PigFeignClientConfiguration.class);
+	}
+
+}


### PR DESCRIPTION
## 变更说明

- 为 PIG Feign 客户端子上下文增加默认配置
- Bean 发布前主动初始化 `FeignHttpMessageConverters`
- 保留自定义 `defaultConfiguration` 的覆盖语义，并补充使用说明
- 增加并发初始化相关回归测试

## 原因

OpenFeign 5.0.2 的转换器首次懒加载存在并发窗口，首次请求可能读到尚未填充完成的空列表。

## 验证

- `mvn -pl pig-common/pig-common-feign -am -Dtest=PigFeignClientConfigurationTests -Dsurefire.failIfNoSpecifiedTests=false test`
- 2 tests passed
- `git diff --check`