### PR TITLE
perf(log): 将日志看板统计下推到数据库

### DIFF
--- a/pig-common/pig-common-bom/pom.xml
+++ b/pig-common/pig-common-bom/pom.xml
@@ -23,6 +23,7 @@
         <oracle.version>21.3.0.0</oracle.version>
         <sqlserver.version>12.10.2.jre8</sqlserver.version>
         <dm.version>8.1.3.140</dm.version>
+        <kingbase.version>9.0.1</kingbase.version>
         <highgo.version>6.2.5</highgo.version>
         <knife4j.version>3.0.5</knife4j.version>
         <springdoc.version>3.0.3</springdoc.version>
@@ -203,6 +204,12 @@
                 <groupId>com.dameng</groupId>
                 <artifactId>DmJdbcDriver18</artifactId>
                 <version>${dm.version}</version>
+            </dependency>
+            <!-- KingbaseES -->
+            <dependency>
+                <groupId>cn.com.kingbase</groupId>
+                <artifactId>kingbase8</artifactId>
+                <version>${kingbase.version}</version>
             </dependency>
             <dependency>
                 <groupId>com.dameng</groupId>

--- a/pig-common/pig-common-data/src/main/java/com/pig4cloud/pig/common/data/mybatis/MybatisPlusConfiguration.java
+++ b/pig-common/pig-common-data/src/main/java/com/pig4cloud/pig/common/data/mybatis/MybatisPlusConfiguration.java
@@ -104,6 +104,7 @@ public class MybatisPlusConfiguration implements WebMvcConfigurer {
 		properties.setProperty("Oracle", "oracle");
 		properties.setProperty("SQL Server", "mssql");
 		properties.setProperty("DM DBMS", "dm");
+		properties.setProperty("KingbaseES", "kingbase");
 		databaseIdProvider.setProperties(properties);
 		return databaseIdProvider;
 	}

--- a/pig-common/pig-common-data/src/main/java/com/pig4cloud/pig/common/data/mybatis/MybatisPlusConfiguration.java
+++ b/pig-common/pig-common-data/src/main/java/com/pig4cloud/pig/common/data/mybatis/MybatisPlusConfiguration.java
@@ -101,7 +101,9 @@ public class MybatisPlusConfiguration implements WebMvcConfigurer {
 	public DatabaseIdProvider databaseIdProvider() {
 		VendorDatabaseIdProvider databaseIdProvider = new VendorDatabaseIdProvider();
 		Properties properties = new Properties();
+		properties.setProperty("Oracle", "oracle");
 		properties.setProperty("SQL Server", "mssql");
+		properties.setProperty("DM DBMS", "dm");
 		databaseIdProvider.setProperties(properties);
 		return databaseIdProvider;
 	}

--- a/pig-upms/pig-upms-biz/pom.xml
+++ b/pig-upms/pig-upms-biz/pom.xml
@@ -58,6 +58,11 @@
             <groupId>com.dameng</groupId>
             <artifactId>DmJdbcDriver18</artifactId>
         </dependency>
+        <!-- KingbaseES -->
+        <dependency>
+            <groupId>cn.com.kingbase</groupId>
+            <artifactId>kingbase8</artifactId>
+        </dependency>
         <!--upms api、model 模块-->
         <dependency>
             <groupId>com.pig4cloud</groupId>

--- a/pig-upms/pig-upms-biz/src/main/java/com/pig4cloud/pig/admin/mapper/SysLogMapper.java
+++ b/pig-upms/pig-upms-biz/src/main/java/com/pig4cloud/pig/admin/mapper/SysLogMapper.java
@@ -22,6 +22,11 @@ package com.pig4cloud.pig.admin.mapper;
 import com.pig4cloud.pig.admin.api.entity.SysLog;
 import com.github.yulichang.base.MPJBaseMapper;
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
 
 /**
  * <p>
@@ -33,5 +38,12 @@ import org.apache.ibatis.annotations.Mapper;
  */
 @Mapper
 public interface SysLogMapper extends MPJBaseMapper<SysLog> {
+
+	/**
+	 * 按日期和日志类型聚合日志数量
+	 * @param startTime 开始时间
+	 * @return 聚合结果
+	 */
+	List<Map<String, Object>> selectLogSum(@Param("startTime") LocalDateTime startTime);
 
 }

--- a/pig-upms/pig-upms-biz/src/main/java/com/pig4cloud/pig/admin/service/impl/SysLogServiceImpl.java
+++ b/pig-upms/pig-upms-biz/src/main/java/com/pig4cloud/pig/admin/service/impl/SysLogServiceImpl.java
@@ -19,8 +19,6 @@
 
 package com.pig4cloud.pig.admin.service.impl;
 
-import cn.hutool.core.date.DatePattern;
-import cn.hutool.core.date.DateUtil;
 import cn.hutool.core.util.ArrayUtil;
 import cn.hutool.core.util.StrUtil;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
@@ -38,10 +36,11 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.time.LocalDateTime;
-import java.util.Comparator;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.stream.Collectors;
+import java.util.TreeMap;
 
 /**
  * <p>
@@ -116,27 +115,20 @@ public class SysLogServiceImpl extends ServiceImpl<SysLogMapper, SysLog> impleme
 	 */
 	@Override
 	public List<Map<String, Object>> getLogSum() {
-		// 查询createTime最近30天的数据
-		List<SysLog> sysLogList = baseMapper
-			.selectList(Wrappers.<SysLog>lambdaQuery().ge(SysLog::getCreateTime, LocalDateTime.now().minusDays(30)));
+		List<Map<String, Object>> logSumList = baseMapper.selectLogSum(LocalDateTime.now().minusDays(30));
+		Map<String, Map<String, Object>> resultMap = new TreeMap<>();
 
-		return sysLogList.stream()
-			// 按照日期进行分组
-			.collect(Collectors.groupingBy(log -> DateUtil.format(log.getCreateTime(), DatePattern.NORM_DATE_PATTERN)))
-			.entrySet()
-			.stream()
-			// 将每个日期对应的日志按日志类型分组，并计算每种类型的日志数量
-			.map(entry -> {
-				Map<String, Object> map = entry.getValue()
-					.stream()
-					.collect(Collectors.groupingBy(SysLog::getLogType,
-							Collectors.collectingAndThen(Collectors.counting(), Long::intValue)));
-				map.put(SysLog.Fields.createTime, entry.getKey());
-				return map;
-			})
-			// 按createTime升序排序
-			.sorted(Comparator.comparing(map -> map.get(SysLog.Fields.createTime).toString()))
-			.toList();
+		for (Map<String, Object> row : logSumList) {
+			String createTime = row.get(SysLog.Fields.createTime).toString();
+			Map<String, Object> logSum = resultMap.computeIfAbsent(createTime, key -> {
+				Map<String, Object> item = new LinkedHashMap<>();
+				item.put(SysLog.Fields.createTime, key);
+				return item;
+			});
+			logSum.put(row.get(SysLog.Fields.logType).toString(), ((Number) row.get("logCount")).intValue());
+		}
+
+		return new ArrayList<>(resultMap.values());
 	}
 
 }

--- a/pig-upms/pig-upms-biz/src/main/java/com/pig4cloud/pig/admin/service/impl/SysLogServiceImpl.java
+++ b/pig-upms/pig-upms-biz/src/main/java/com/pig4cloud/pig/admin/service/impl/SysLogServiceImpl.java
@@ -35,6 +35,8 @@ import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -119,7 +121,7 @@ public class SysLogServiceImpl extends ServiceImpl<SysLogMapper, SysLog> impleme
 		Map<String, Map<String, Object>> resultMap = new TreeMap<>();
 
 		for (Map<String, Object> row : logSumList) {
-			String createTime = row.get(SysLog.Fields.createTime).toString();
+			String createTime = formatCreateTime(row.get(SysLog.Fields.createTime));
 			Map<String, Object> logSum = resultMap.computeIfAbsent(createTime, key -> {
 				Map<String, Object> item = new LinkedHashMap<>();
 				item.put(SysLog.Fields.createTime, key);
@@ -129,6 +131,19 @@ public class SysLogServiceImpl extends ServiceImpl<SysLogMapper, SysLog> impleme
 		}
 
 		return new ArrayList<>(resultMap.values());
+	}
+
+	private String formatCreateTime(Object createTime) {
+		if (createTime instanceof Timestamp timestamp) {
+			return timestamp.toLocalDateTime().toLocalDate().toString();
+		}
+		if (createTime instanceof LocalDateTime localDateTime) {
+			return localDateTime.toLocalDate().toString();
+		}
+		if (createTime instanceof LocalDate localDate) {
+			return localDate.toString();
+		}
+		return createTime.toString();
 	}
 
 }

--- a/pig-upms/pig-upms-biz/src/main/resources/mapper/SysLogMapper.xml
+++ b/pig-upms/pig-upms-biz/src/main/resources/mapper/SysLogMapper.xml
@@ -27,8 +27,42 @@
 			COUNT(*) AS "logCount"
 		FROM sys_log
 		WHERE create_time >= #{startTime}
+			AND del_flag = '0'
 		GROUP BY DATE(create_time), log_type
 		ORDER BY DATE(create_time), log_type
+	</select>
+
+	<select id="selectLogSum" databaseId="oracle" resultType="java.util.Map">
+		SELECT TRUNC(create_time) AS "createTime",
+			log_type AS "logType",
+			COUNT(*) AS "logCount"
+		FROM sys_log
+		WHERE create_time >= #{startTime}
+			AND del_flag = '0'
+		GROUP BY TRUNC(create_time), log_type
+		ORDER BY TRUNC(create_time), log_type
+	</select>
+
+	<select id="selectLogSum" databaseId="mssql" resultType="java.util.Map">
+		SELECT CAST(create_time AS date) AS "createTime",
+			log_type AS "logType",
+			COUNT(*) AS "logCount"
+		FROM sys_log
+		WHERE create_time >= #{startTime}
+			AND del_flag = '0'
+		GROUP BY CAST(create_time AS date), log_type
+		ORDER BY CAST(create_time AS date), log_type
+	</select>
+
+	<select id="selectLogSum" databaseId="dm" resultType="java.util.Map">
+		SELECT TO_CHAR(create_time, 'YYYY-MM-DD') AS "createTime",
+			log_type AS "logType",
+			COUNT(*) AS "logCount"
+		FROM sys_log
+		WHERE create_time >= #{startTime}
+			AND del_flag = '0'
+		GROUP BY TO_CHAR(create_time, 'YYYY-MM-DD'), log_type
+		ORDER BY TO_CHAR(create_time, 'YYYY-MM-DD'), log_type
 	</select>
 
 </mapper>

--- a/pig-upms/pig-upms-biz/src/main/resources/mapper/SysLogMapper.xml
+++ b/pig-upms/pig-upms-biz/src/main/resources/mapper/SysLogMapper.xml
@@ -65,4 +65,15 @@
 		ORDER BY TO_CHAR(create_time, 'YYYY-MM-DD'), log_type
 	</select>
 
+	<select id="selectLogSum" databaseId="kingbase" resultType="java.util.Map">
+		SELECT TO_CHAR(create_time, 'YYYY-MM-DD') AS "createTime",
+			log_type AS "logType",
+			COUNT(*) AS "logCount"
+		FROM sys_log
+		WHERE create_time >= #{startTime}
+			AND del_flag = '0'
+		GROUP BY TO_CHAR(create_time, 'YYYY-MM-DD'), log_type
+		ORDER BY TO_CHAR(create_time, 'YYYY-MM-DD'), log_type
+	</select>
+
 </mapper>

--- a/pig-upms/pig-upms-biz/src/main/resources/mapper/SysLogMapper.xml
+++ b/pig-upms/pig-upms-biz/src/main/resources/mapper/SysLogMapper.xml
@@ -21,4 +21,14 @@
 <!DOCTYPE mapper PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN" "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.pig4cloud.pig.admin.mapper.SysLogMapper">
 
+	<select id="selectLogSum" resultType="java.util.Map">
+		SELECT DATE(create_time) AS "createTime",
+			log_type AS "logType",
+			COUNT(*) AS "logCount"
+		FROM sys_log
+		WHERE create_time >= #{startTime}
+		GROUP BY DATE(create_time), log_type
+		ORDER BY DATE(create_time), log_type
+	</select>
+
 </mapper>

--- a/pig-upms/pig-upms-biz/src/test/java/com/pig4cloud/pig/admin/mapper/SysLogMapperXmlTests.java
+++ b/pig-upms/pig-upms-biz/src/test/java/com/pig4cloud/pig/admin/mapper/SysLogMapperXmlTests.java
@@ -1,0 +1,87 @@
+/*
+ *    Copyright (c) 2018-2026, lengleng All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * Neither the name of the pig4cloud.com developer nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * Author: lengleng (wangiegie@gmail.com)
+ */
+
+package com.pig4cloud.pig.admin.mapper;
+
+import com.pig4cloud.pig.common.data.mybatis.MybatisPlusConfiguration;
+import org.apache.ibatis.builder.xml.XMLMapperBuilder;
+import org.apache.ibatis.io.Resources;
+import org.apache.ibatis.mapping.DatabaseIdProvider;
+import org.apache.ibatis.session.Configuration;
+import org.junit.jupiter.api.Test;
+
+import javax.sql.DataSource;
+import java.io.IOException;
+import java.io.InputStream;
+import java.sql.Connection;
+import java.sql.DatabaseMetaData;
+import java.sql.SQLException;
+import java.time.LocalDateTime;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SysLogMapperXmlTests {
+
+	private static final String MAPPER_RESOURCE = "mapper/SysLogMapper.xml";
+
+	private static final String STATEMENT_ID = "com.pig4cloud.pig.admin.mapper.SysLogMapper.selectLogSum";
+
+	@Test
+	void selectLogSumUsesDialectSpecificDateBucketsAndExcludesDeletedLogs() throws IOException {
+		assertThat(sql(null)).contains("DATE(create_time)").contains("del_flag = '0'");
+		assertThat(sql("oracle")).contains("TRUNC(create_time)").contains("del_flag = '0'");
+		assertThat(sql("mssql")).contains("CAST(create_time AS date)").contains("del_flag = '0'");
+		assertThat(sql("dm")).contains("TO_CHAR(create_time, 'YYYY-MM-DD')").contains("del_flag = '0'");
+	}
+
+	@Test
+	void databaseIdProviderRecognizesSupportedDialectProductNames() throws SQLException {
+		DatabaseIdProvider provider = new MybatisPlusConfiguration().databaseIdProvider();
+
+		assertThat(databaseId(provider, "Oracle")).isEqualTo("oracle");
+		assertThat(databaseId(provider, "Microsoft SQL Server")).isEqualTo("mssql");
+		assertThat(databaseId(provider, "DM DBMS")).isEqualTo("dm");
+	}
+
+	private String sql(String databaseId) throws IOException {
+		Configuration configuration = new Configuration();
+		configuration.setDatabaseId(databaseId);
+		try (InputStream inputStream = Resources.getResourceAsStream(MAPPER_RESOURCE)) {
+			XMLMapperBuilder mapperBuilder = new XMLMapperBuilder(inputStream, configuration, MAPPER_RESOURCE,
+					configuration.getSqlFragments());
+			mapperBuilder.parse();
+		}
+		return configuration.getMappedStatement(STATEMENT_ID)
+			.getBoundSql(Map.of("startTime", LocalDateTime.now()))
+			.getSql()
+			.replaceAll("\\s+", " ");
+	}
+
+	private String databaseId(DatabaseIdProvider provider, String productName) throws SQLException {
+		DataSource dataSource = mock(DataSource.class);
+		Connection connection = mock(Connection.class);
+		DatabaseMetaData metadata = mock(DatabaseMetaData.class);
+		when(dataSource.getConnection()).thenReturn(connection);
+		when(connection.getMetaData()).thenReturn(metadata);
+		when(metadata.getDatabaseProductName()).thenReturn(productName);
+		return provider.getDatabaseId(dataSource);
+	}
+
+}

--- a/pig-upms/pig-upms-biz/src/test/java/com/pig4cloud/pig/admin/mapper/SysLogMapperXmlTests.java
+++ b/pig-upms/pig-upms-biz/src/test/java/com/pig4cloud/pig/admin/mapper/SysLogMapperXmlTests.java
@@ -49,6 +49,7 @@ class SysLogMapperXmlTests {
 		assertThat(sql("oracle")).contains("TRUNC(create_time)").contains("del_flag = '0'");
 		assertThat(sql("mssql")).contains("CAST(create_time AS date)").contains("del_flag = '0'");
 		assertThat(sql("dm")).contains("TO_CHAR(create_time, 'YYYY-MM-DD')").contains("del_flag = '0'");
+		assertThat(sql("kingbase")).contains("TO_CHAR(create_time, 'YYYY-MM-DD')").contains("del_flag = '0'");
 	}
 
 	@Test
@@ -58,6 +59,7 @@ class SysLogMapperXmlTests {
 		assertThat(databaseId(provider, "Oracle")).isEqualTo("oracle");
 		assertThat(databaseId(provider, "Microsoft SQL Server")).isEqualTo("mssql");
 		assertThat(databaseId(provider, "DM DBMS")).isEqualTo("dm");
+		assertThat(databaseId(provider, "KingbaseES")).isEqualTo("kingbase");
 	}
 
 	private String sql(String databaseId) throws IOException {

--- a/pig-upms/pig-upms-biz/src/test/java/com/pig4cloud/pig/admin/service/impl/SysLogServiceImplTests.java
+++ b/pig-upms/pig-upms-biz/src/test/java/com/pig4cloud/pig/admin/service/impl/SysLogServiceImplTests.java
@@ -21,6 +21,7 @@ import com.pig4cloud.pig.admin.mapper.SysLogMapper;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.sql.Timestamp;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -49,7 +50,20 @@ class SysLogServiceImplTests {
 		verify(sysLogMapper).selectLogSum(any());
 	}
 
-	private Map<String, Object> row(String createTime, String logType, long logCount) {
+	@Test
+	void getLogSumNormalizesTimestampBucketsFromOracle() {
+		SysLogMapper sysLogMapper = mock(SysLogMapper.class);
+		SysLogServiceImpl service = new SysLogServiceImpl();
+		ReflectionTestUtils.setField(service, "baseMapper", sysLogMapper);
+		when(sysLogMapper.selectLogSum(any()))
+			.thenReturn(List.of(row(Timestamp.valueOf("2026-07-13 00:00:00"), "0", 12L)));
+
+		List<Map<String, Object>> result = service.getLogSum();
+
+		assertThat(result).containsExactly(Map.of("createTime", "2026-07-13", "0", 12));
+	}
+
+	private Map<String, Object> row(Object createTime, String logType, long logCount) {
 		Map<String, Object> row = new LinkedHashMap<>();
 		row.put("createTime", createTime);
 		row.put("logType", logType);

--- a/pig-upms/pig-upms-biz/src/test/java/com/pig4cloud/pig/admin/service/impl/SysLogServiceImplTests.java
+++ b/pig-upms/pig-upms-biz/src/test/java/com/pig4cloud/pig/admin/service/impl/SysLogServiceImplTests.java
@@ -1,0 +1,60 @@
+/*
+ *    Copyright (c) 2018-2026, lengleng All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * Neither the name of the pig4cloud.com developer nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * Author: lengleng (wangiegie@gmail.com)
+ */
+
+package com.pig4cloud.pig.admin.service.impl;
+
+import com.pig4cloud.pig.admin.mapper.SysLogMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class SysLogServiceImplTests {
+
+	@Test
+	void getLogSumUsesDatabaseAggregationAndKeepsResponseShape() {
+		SysLogMapper sysLogMapper = mock(SysLogMapper.class);
+		SysLogServiceImpl service = new SysLogServiceImpl();
+		ReflectionTestUtils.setField(service, "baseMapper", sysLogMapper);
+		when(sysLogMapper.selectLogSum(any()))
+			.thenReturn(List.of(row("2026-07-13", "0", 12L), row("2026-07-13", "9", 3L), row("2026-07-14", "0", 8L)));
+		when(sysLogMapper.selectList(any())).thenThrow(new AssertionError("不应加载日志实体进行内存聚合"));
+
+		List<Map<String, Object>> result = service.getLogSum();
+
+		assertThat(result).containsExactly(Map.of("createTime", "2026-07-13", "0", 12, "9", 3),
+				Map.of("createTime", "2026-07-14", "0", 8));
+		verify(sysLogMapper).selectLogSum(any());
+	}
+
+	private Map<String, Object> row(String createTime, String logType, long logCount) {
+		Map<String, Object> row = new LinkedHashMap<>();
+		row.put("createTime", createTime);
+		row.put("logType", logType);
+		row.put("logCount", logCount);
+		return row;
+	}
+
+}


### PR DESCRIPTION
## 变更说明

- 新增按日期、日志类型聚合的 Mapper 查询
- `getLogSum` 改为消费数据库聚合结果，避免加载近 30 天全部日志实体后在 JVM 内分组
- 聚合 SQL 增加 `del_flag = '0'`，排除已经逻辑删除的日志
- 通过 MyBatis `databaseId` 维护数据库方言：
  - MySQL / PostgreSQL：`DATE(create_time)`
  - Oracle：`TRUNC(create_time)`
  - SQL Server：`CAST(create_time AS date)`
  - DM8 / KingbaseES：`TO_CHAR(create_time, 'YYYY-MM-DD')`
- 增加 Oracle、SQL Server、DM8、KingbaseES 产品名映射
- 引入 KingbaseES JDBC 驱动，并由项目 BOM 统一管理版本
- 规范化 Oracle 等数据库可能返回的午夜时间戳，保持接口 `yyyy-MM-dd` 响应结构
- 增加服务层、方言选择、逻辑删除和 databaseId 映射回归测试

## 原因与影响

原实现需要把近 30 天日志实体全部载入 JVM 后进行分组，日志量大时会造成额外内存与 GC 压力。初次下推 SQL 后，手写查询没有自动附加 MyBatis-Plus 的逻辑删除条件，并且使用了仅部分数据库支持的日期函数。

本次修复后，聚合由数据库完成，逻辑删除语义与旧实现一致，同时覆盖项目打包支持的主要数据库及 KingbaseES。

## 验证

- MyBatis 解析器验证 generic、Oracle、SQL Server、DM8、KingbaseES 五套聚合 SQL 均能按 databaseId 命中
- 所有聚合 SQL 均包含 `del_flag = '0'`
- KingbaseES 驱动依赖解析为 `cn.com.kingbase:kingbase8:9.0.1`
- Spring Java Format 校验通过
- POM、Mapper XML 结构校验通过
- `git diff --check` 通过

完整 Maven reactor 仍受 `dev` 基线的 MyBatis-Plus 3.5.17 ActiveRecord `Model` 类迁移问题影响，在 `pig-common-data/DictResolver.java` 编译阶段停止；该问题不由本 PR 引入。
