### PR TITLE
fix(deps): 回滚 MyBatis-Plus 至 3.5.16

### DIFF
--- a/pig-common/pig-common-bom/pom.xml
+++ b/pig-common/pig-common-bom/pom.xml
@@ -12,9 +12,9 @@
 
     <properties>
         <pig.version>4.1.0</pig.version>
-        <mybatis-plus.version>3.5.17</mybatis-plus.version>
+        <mybatis-plus.version>3.5.16</mybatis-plus.version>
         <mybatis-spring-boot.version>4.0.1</mybatis-spring-boot.version>
-        <mybatis-plus-join.version>1.5.9</mybatis-plus-join.version>
+        <mybatis-plus-join.version>1.5.7</mybatis-plus-join.version>
         <dynamic-ds.version>4.5.0</dynamic-ds.version>
         <nacos.client.version>3.2.3</nacos.client.version>
         <druid.version>1.2.28</druid.version>


### PR DESCRIPTION
## 变更说明

- `mybatis-plus.version`：3.5.17 → **3.5.16**
- `mybatis-plus-join.version`：1.5.9 → **1.5.7**

## 原因

MyBatis-Plus 3.5.17 将 ActiveRecord `Model` 包迁移，导致 `dev` 基线实体仍引用旧包名时编译失败，阻塞后续 PR 的 Maven CI。

## 验证

- 版本仅在 `pig-common/pig-common-bom/pom.xml` 统一声明
- 预期恢复后 `mvn` 可正常解析 `com.baomidou.mybatisplus.extension.activerecord.Model`