### PR TITLE
fix(log): 兼容多数据库日期汇总结果

### DIFF
--- a/pig-upms/pig-upms-biz/src/main/java/com/pig4cloud/pig/admin/service/impl/SysLogServiceImpl.java
+++ b/pig-upms/pig-upms-biz/src/main/java/com/pig4cloud/pig/admin/service/impl/SysLogServiceImpl.java
@@ -19,6 +19,9 @@
 
 package com.pig4cloud.pig.admin.service.impl;
 
+import cn.hutool.core.date.DatePattern;
+import cn.hutool.core.date.DateUtil;
+import cn.hutool.core.date.TemporalAccessorUtil;
 import cn.hutool.core.util.ArrayUtil;
 import cn.hutool.core.util.StrUtil;
 import com.baomidou.mybatisplus.core.conditions.query.LambdaQueryWrapper;
@@ -35,10 +38,10 @@ import org.springframework.beans.BeanUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.sql.Timestamp;
-import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.time.temporal.TemporalAccessor;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -134,14 +137,14 @@ public class SysLogServiceImpl extends ServiceImpl<SysLogMapper, SysLog> impleme
 	}
 
 	private String formatCreateTime(Object createTime) {
-		if (createTime instanceof Timestamp timestamp) {
-			return timestamp.toLocalDateTime().toLocalDate().toString();
+		if (createTime == null) {
+			return StrUtil.EMPTY;
 		}
-		if (createTime instanceof LocalDateTime localDateTime) {
-			return localDateTime.toLocalDate().toString();
+		if (createTime instanceof Date date) {
+			return DateUtil.format(date, DatePattern.NORM_DATE_PATTERN);
 		}
-		if (createTime instanceof LocalDate localDate) {
-			return localDate.toString();
+		if (createTime instanceof TemporalAccessor temporalAccessor) {
+			return TemporalAccessorUtil.format(temporalAccessor, DatePattern.NORM_DATE_PATTERN);
 		}
 		return createTime.toString();
 	}

--- a/pig-upms/pig-upms-biz/src/test/java/com/pig4cloud/pig/admin/service/impl/SysLogServiceImplTests.java
+++ b/pig-upms/pig-upms-biz/src/test/java/com/pig4cloud/pig/admin/service/impl/SysLogServiceImplTests.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.sql.Timestamp;
+import java.time.LocalDate;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -61,6 +62,20 @@ class SysLogServiceImplTests {
 		List<Map<String, Object>> result = service.getLogSum();
 
 		assertThat(result).containsExactly(Map.of("createTime", "2026-07-13", "0", 12));
+	}
+
+	@Test
+	void getLogSumNormalizesTemporalAccessorAndNullBuckets() {
+		SysLogMapper sysLogMapper = mock(SysLogMapper.class);
+		SysLogServiceImpl service = new SysLogServiceImpl();
+		ReflectionTestUtils.setField(service, "baseMapper", sysLogMapper);
+		when(sysLogMapper.selectLogSum(any()))
+			.thenReturn(List.of(row(null, "0", 1L), row(LocalDate.of(2026, 7, 14), "0", 8L)));
+
+		List<Map<String, Object>> result = service.getLogSum();
+
+		assertThat(result).containsExactly(Map.of("createTime", "", "0", 1),
+				Map.of("createTime", "2026-07-14", "0", 8));
 	}
 
 	private Map<String, Object> row(Object createTime, String logType, long logCount) {


### PR DESCRIPTION
## 变更说明

- 同步商业版 `d70f4a35b` 中日志多数据源汇总的日期结果格式化逻辑
- 支持 JDBC 返回的任意 `java.util.Date` 类型
- 支持 `LocalDate`、`LocalDateTime` 等 `TemporalAccessor` 类型
- 对空日期值使用空字符串兜底
- 保持 `/log/sum` 的 `yyyy-MM-dd` 响应结构不变
- 增加 TemporalAccessor 和空值回归测试

## 原因与影响

不同数据库及 JDBC 驱动可能将按日聚合结果映射为 `Timestamp`、其他 `Date` 子类或 Java Time 类型。此前仅针对少数具体类型处理，新增数据库方言后仍可能产生带时分秒的日期字符串或空值异常。

本次调整统一格式化这些结果，避免 Oracle、DM8、KingbaseES 等数据库返回类型差异影响日志看板接口。

## 验证

- `mvn -pl pig-upms/pig-upms-biz -am -Dmybatis-plus.version=3.5.16 -Dtest=SysLogServiceImplTests,SysLogMapperXmlTests -Dsurefire.failIfNoSpecifiedTests=false test`
- 5 tests passed，0 failures
- Spring Java Format 校验通过
- `git diff --check` 通过