### PR TITLE
fix(codegen): 拦截非法表名

### DIFF
--- a/pig-visual/pig-codegen/src/main/java/com/pig4cloud/pig/codegen/controller/GenCreateTableController.java
+++ b/pig-visual/pig-codegen/src/main/java/com/pig4cloud/pig/codegen/controller/GenCreateTableController.java
@@ -19,6 +19,7 @@ package com.pig4cloud.pig.codegen.controller;
 import cn.hutool.json.JSONUtil;
 import com.baomidou.mybatisplus.core.conditions.query.QueryWrapper;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.baomidou.mybatisplus.core.toolkit.sql.SqlInjectionUtils;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.pig4cloud.pig.codegen.entity.GenCreateTable;
 import com.pig4cloud.pig.codegen.service.GenCreateTableService;
@@ -30,6 +31,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.*;
 
@@ -42,6 +44,7 @@ import java.util.List;
  * @date 2022-09-23 21:56:11
  */
 @RestController
+@Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/create-table")
 @Tag(description = "create-table", name = "自动创建表管理管理")
@@ -84,6 +87,10 @@ public class GenCreateTableController {
 	@PostMapping
 	@HasPermission("codegen_table_add")
 	public R save(@RequestBody GenCreateTableVO createTableVO) {
+		if (SqlInjectionUtils.check(createTableVO.getTableName())) {
+			log.warn("代码生成检测到非法表名，dsName: {}, tableName: {}", createTableVO.getDsName(), createTableVO.getTableName());
+			return R.failed("非法内容");
+		}
 		AnylineDataSourceHelper.run(createTableVO.getDsName(), () -> createTableService.createTable(createTableVO));
 		GenCreateTable createTable = new GenCreateTable();
 		createTable.setId(createTableVO.getId());

--- a/pig-visual/pig-codegen/src/main/java/com/pig4cloud/pig/codegen/controller/GenTableController.java
+++ b/pig-visual/pig-codegen/src/main/java/com/pig4cloud/pig/codegen/controller/GenTableController.java
@@ -19,6 +19,7 @@ package com.pig4cloud.pig.codegen.controller;
 
 import com.baomidou.dynamic.datasource.toolkit.DynamicDataSourceContextHolder;
 import com.baomidou.mybatisplus.core.toolkit.Wrappers;
+import com.baomidou.mybatisplus.core.toolkit.sql.SqlInjectionUtils;
 import com.baomidou.mybatisplus.extension.plugins.pagination.Page;
 import com.pig4cloud.pig.codegen.entity.GenTable;
 import com.pig4cloud.pig.codegen.entity.GenTableColumnEntity;
@@ -31,6 +32,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.bind.annotation.*;
 
@@ -43,6 +45,7 @@ import java.util.List;
  * @date 2023-02-06 20:34:55
  */
 @RestController
+@Slf4j
 @RequiredArgsConstructor
 @RequestMapping("/table")
 @Tag(description = "table", name = "列属性管理")
@@ -92,6 +95,10 @@ public class GenTableController {
 	 */
 	@GetMapping("/{dsName}/{tableName}")
 	public R<GenTable> getTable(@PathVariable("dsName") String dsName, @PathVariable String tableName) {
+		if (SqlInjectionUtils.check(tableName)) {
+			log.warn("代码生成检测到非法表名，dsName: {}, tableName: {}", dsName, tableName);
+			return R.failed("非法内容");
+		}
 		return R.ok(tableService.queryOrBuildTable(dsName, tableName));
 	}
 
@@ -102,6 +109,10 @@ public class GenTableController {
 	 */
 	@GetMapping("/column/{dsName}/{tableName}")
 	public R getColumn(@PathVariable("dsName") String dsName, @PathVariable String tableName) throws Exception {
+		if (SqlInjectionUtils.check(tableName)) {
+			log.warn("代码生成检测到非法表名，dsName: {}, tableName: {}", dsName, tableName);
+			return R.failed("非法内容");
+		}
 		return R.ok(tableService.queryTableColumn(dsName, tableName));
 	}
 
@@ -112,6 +123,10 @@ public class GenTableController {
 	 */
 	@GetMapping("/ddl/{dsName}/{tableName}")
 	public R getDdl(@PathVariable("dsName") String dsName, @PathVariable String tableName) throws Exception {
+		if (SqlInjectionUtils.check(tableName)) {
+			log.warn("代码生成检测到非法表名，dsName: {}, tableName: {}", dsName, tableName);
+			return R.failed("非法内容");
+		}
 		return R.ok(tableService.queryTableDdl(dsName, tableName));
 	}
 
@@ -123,6 +138,10 @@ public class GenTableController {
 	 */
 	@GetMapping("/sync/{dsName}/{tableName}")
 	public R<GenTable> syncTable(@PathVariable("dsName") String dsName, @PathVariable String tableName) {
+		if (SqlInjectionUtils.check(tableName)) {
+			log.warn("代码生成检测到非法表名，dsName: {}, tableName: {}", dsName, tableName);
+			return R.failed("非法内容");
+		}
 		return R.ok(tableService.syncTable(dsName, tableName));
 	}
 

--- a/pig-visual/pig-codegen/src/test/java/com/pig4cloud/pig/codegen/controller/GenCreateTableControllerTests.java
+++ b/pig-visual/pig-codegen/src/test/java/com/pig4cloud/pig/codegen/controller/GenCreateTableControllerTests.java
@@ -1,0 +1,29 @@
+package com.pig4cloud.pig.codegen.controller;
+
+import com.pig4cloud.pig.codegen.service.GenCreateTableService;
+import com.pig4cloud.pig.codegen.util.vo.GenCreateTableVO;
+import com.pig4cloud.pig.common.core.util.R;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+class GenCreateTableControllerTests {
+
+	@Test
+	void rejectsInjectedTableNameBeforeCreatingTable() {
+		GenCreateTableService service = mock(GenCreateTableService.class);
+		GenCreateTableController controller = new GenCreateTableController(service);
+		GenCreateTableVO request = new GenCreateTableVO();
+		request.setDsName("master");
+		request.setTableName("sys_user WHERE 1=EXTRACTVALUE(1,CONCAT(0x7e,user(),0x7e))#");
+
+		R result = controller.save(request);
+
+		assertThat(result.isOk()).isFalse();
+		assertThat(result.getMsg()).isEqualTo("非法内容");
+		verifyNoInteractions(service);
+	}
+
+}

--- a/pig-visual/pig-codegen/src/test/java/com/pig4cloud/pig/codegen/controller/GenTableControllerTests.java
+++ b/pig-visual/pig-codegen/src/test/java/com/pig4cloud/pig/codegen/controller/GenTableControllerTests.java
@@ -1,0 +1,43 @@
+package com.pig4cloud.pig.codegen.controller;
+
+import com.pig4cloud.pig.codegen.service.GenTableColumnService;
+import com.pig4cloud.pig.codegen.service.GenTableService;
+import com.pig4cloud.pig.common.core.util.R;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class GenTableControllerTests {
+
+	private final GenTableColumnService tableColumnService = mock(GenTableColumnService.class);
+
+	private final GenTableService tableService = mock(GenTableService.class);
+
+	private final GenTableController controller = new GenTableController(tableColumnService, tableService);
+
+	@Test
+	void rejectsIssue1273PayloadBeforeCallingService() throws Exception {
+		String tableName = "fcrawler_demo_item WHERE 1=EXTRACTVALUE(1,CONCAT(0x7e,user(),0x7e))#";
+
+		R result = controller.getColumn("master", tableName);
+
+		assertThat(result.isOk()).isFalse();
+		assertThat(result.getMsg()).isEqualTo("非法内容");
+		verifyNoInteractions(tableService);
+	}
+
+	@Test
+	void acceptsRegularTableName() throws Exception {
+		when(tableService.queryTableColumn("master", "sys_user")).thenReturn(List.of());
+
+		R result = controller.getColumn("master", "sys_user");
+
+		assertThat(result.isOk()).isTrue();
+	}
+
+}


### PR DESCRIPTION
## 变更内容

- 在建表保存入口校验表名，命中 SQL 注入特征时提前拒绝。
- 在表元数据、字段、DDL 和同步入口统一校验表名。
- 增加控制器回归测试，覆盖注入载荷和正常表名。

## 原因

代码生成接口此前会将客户端传入的表名继续交给元数据和建表服务处理，入口缺少统一的非法内容校验。构造后的表名表达式可能进入下游动态 SQL 或元数据查询链路。

## 影响

非法表名会返回“非法内容”，且不会调用下游服务；正常表名流程保持不变。

## 验证

- `mvn -pl pig-visual/pig-codegen -am -Dtest=GenCreateTableControllerTests,GenTableControllerTests -Dsurefire.failIfNoSpecifiedTests=false test`
- 3 个回归测试通过，0 failures / 0 errors
- `git diff --check`