### PR TITLE
fix(config): 避免 Nacos 刷新触发数据源循环

### DIFF
--- a/db/pig_config.sql
+++ b/db/pig_config.sql
@@ -44,9 +44,16 @@ INSERT INTO `config_info` (`id`, `data_id`, `group_id`, `content`, `md5`, `gmt_c
 INSERT INTO `config_info` (`id`, `data_id`, `group_id`, `content`, `md5`, `gmt_create`, `gmt_modified`, `src_user`, `src_ip`, `app_name`, `tenant_id`, `c_desc`, `c_use`, `effect`, `type`, `c_schema`, `encrypted_data_key`) VALUES (8, 'pig-quartz-dev.yml', 'DEFAULT_GROUP', '# 数据源\nspring:\n  datasource:\n    type: com.alibaba.druid.pool.DruidDataSource\n    druid:\n      driver-class-name: com.mysql.cj.jdbc.Driver\n      username: ${MYSQL_USER:root}\n      password: ${MYSQL_PWD:root}\n      url: jdbc:mysql://${MYSQL_HOST:pig-mysql}:${MYSQL_PORT:3306}/${MYSQL_DB:pig}?characterEncoding=utf8&zeroDateTimeBehavior=convertToNull&useSSL=false&useJDBCCompliantTimezoneShift=true&useLegacyDatetimeCode=false&serverTimezone=GMT%2B8&allowMultiQueries=true&allowPublicKeyRetrieval=true\n  resources:\n    static-locations: classpath:/static/,classpath:/views/', 'ccc0363f94bcb81a0318e06eecdbcac2', '2022-12-16 10:44:25', '2024-04-19 21:49:00', 'nacos', '127.0.0.1', '', 'public', '', '', '', 'yaml', '', '');
 UPDATE `config_info`
 SET `content` = REPLACE(`content`,
+                        '  cloud:\n    nacos:',
+                        '  cloud:\n    refresh:\n      never-refreshable: datasource\n    nacos:'),
+    `md5` = 'b067ee14ae8f19a8bf14657dcbd1ca52'
+WHERE `id` = 1
+  AND `data_id` = 'application-dev.yml';
+UPDATE `config_info`
+SET `content` = REPLACE(`content`,
                         '      update-strategy: not_null\n  type-handlers-package:',
                         '      update-strategy: not_null\n    sequence:\n      worker-id: ${random.int(1,31)}\n      datacenter-id: ${random.int(1,31)}\n  type-handlers-package:'),
-    `md5` = '211580957279a4c25b7522cae8252658'
+    `md5` = '9ed950c40a8c97dbae4275619d3ebe87'
 WHERE `id` = 1
   AND `data_id` = 'application-dev.yml';
 COMMIT;

--- a/pig-common/pig-common-log/src/main/java/com/pig4cloud/pig/common/log/config/PigLogProperties.java
+++ b/pig-common/pig-common-log/src/main/java/com/pig4cloud/pig/common/log/config/PigLogProperties.java
@@ -18,7 +18,6 @@ package com.pig4cloud.pig.common.log.config;
 
 import lombok.Getter;
 import lombok.Setter;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 import java.util.List;
@@ -48,8 +47,8 @@ public class PigLogProperties {
 	/**
 	 * 放行字段，password,mobile,idcard,phone
 	 */
-	@Value("${pig.log.exclude-fields:password,mobile,idcard,phone,accessSecret,tokenId,sign}")
-	private List<String> excludeFields;
+	private List<String> excludeFields = List.of("password", "mobile", "idcard", "phone", "accessSecret", "tokenId",
+			"sign");
 
 	/**
 	 * 请求报文最大存储长度


### PR DESCRIPTION
## 改了什么

- 在 Nacos 公共配置中增加 `spring.cloud.refresh.never-refreshable: datasource`，阻止配置刷新时重建数据源。
- 移除 `PigLogProperties.excludeFields` 上的 `@Value` 动态注入，改为由 `@ConfigurationProperties` 属性提供默认列表。
- 同步更新种子 SQL 中配置内容对应的 MD5。

## 为什么修改

Nacos 配置刷新会触发数据源及日志配置 Bean 的重复刷新。数据源刷新可能进入循环，最终导致服务实例 DOWN；日志配置中的 `@Value` 动态注入也会参与刷新依赖链，放大循环风险。

## 影响

- Nacos 配置变更时不再刷新数据源，避免服务因刷新循环下线。
- `pig.log.exclude-fields` 仍可通过 `@ConfigurationProperties` 正常绑定；未配置时继续使用原有默认脱敏字段。
- 不涉及前端、业务接口或数据库表结构变更。

## 验证

- `mvn -pl pig-common/pig-common-log spring-javaformat:validate`
- `mvn -pl pig-common/pig-common-log -am -DskipTests compile`
- `git diff --check origin/dev...HEAD`
- 校验 Nacos 配置两阶段替换均唯一命中，且每一步 MD5 与实际配置内容一致
