### PR TITLE
fix(quartz): 增加 REST 任务 URL 白名单校验

### DIFF
--- a/pig-visual/pig-quartz/src/main/java/com/pig4cloud/pig/daemon/quartz/config/QuartzProtectionProperties.java
+++ b/pig-visual/pig-quartz/src/main/java/com/pig4cloud/pig/daemon/quartz/config/QuartzProtectionProperties.java
@@ -3,6 +3,9 @@ package com.pig4cloud.pig.daemon.quartz.config;
 import lombok.Data;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+import java.util.HashSet;
+import java.util.Set;
+
 /**
  * Quartz 重复触发保护配置。
  * <p>
@@ -32,5 +35,15 @@ public class QuartzProtectionProperties {
 	 * 是否记录跳过日志
 	 */
 	private boolean logSkipped = true;
+
+	/**
+	 * REST 任务允许访问的 URL 源白名单。
+	 * <p>
+	 * 白名单项格式为 {@code scheme://host[:port]}，例如
+	 * {@code https://api.example.com}。匹配时仅比较协议、主机和有效端口， 任务地址可以携带具体的路径和查询参数。空白名单默认拒绝所有
+	 * REST 任务请求。
+	 * </p>
+	 */
+	private Set<String> restTaskUrlWhitelist = new HashSet<>();
 
 }

--- a/pig-visual/pig-quartz/src/main/java/com/pig4cloud/pig/daemon/quartz/controller/SysJobController.java
+++ b/pig-visual/pig-quartz/src/main/java/com/pig4cloud/pig/daemon/quartz/controller/SysJobController.java
@@ -27,11 +27,13 @@ import com.pig4cloud.pig.common.excel.annotation.ResponseExcel;
 import com.pig4cloud.pig.common.log.annotation.SysLog;
 import com.pig4cloud.pig.common.security.annotation.HasPermission;
 import com.pig4cloud.pig.common.security.util.SecurityUtils;
+import com.pig4cloud.pig.daemon.quartz.constants.JobTypeQuartzEnum;
 import com.pig4cloud.pig.daemon.quartz.constants.PigQuartzEnum;
 import com.pig4cloud.pig.daemon.quartz.entity.SysJob;
 import com.pig4cloud.pig.daemon.quartz.entity.SysJobLog;
 import com.pig4cloud.pig.daemon.quartz.service.SysJobLogService;
 import com.pig4cloud.pig.daemon.quartz.service.SysJobService;
+import com.pig4cloud.pig.daemon.quartz.util.RestTaskUrlValidator;
 import com.pig4cloud.pig.daemon.quartz.util.TaskUtil;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.security.SecurityRequirement;
@@ -63,6 +65,8 @@ public class SysJobController {
 	private final TaskUtil taskUtil;
 
 	private final Scheduler scheduler;
+
+	private final RestTaskUrlValidator restTaskUrlValidator;
 
 	/**
 	 * 定时任务分页查询
@@ -115,6 +119,9 @@ public class SysJobController {
 	@HasPermission("job_sys_job_add")
 	@Operation(description = "新增定时任务")
 	public R save(@RequestBody SysJob sysJob) {
+		if (!isRestTaskUrlAllowed(sysJob)) {
+			return R.failed("REST任务地址未配置白名单或不在白名单中");
+		}
 		// 初始化任务
 		taskUtil.addOrUpateJob(sysJob, scheduler);
 		sysJob.setJobStatus(PigQuartzEnum.JOB_STATUS_RELEASE.getType());
@@ -132,6 +139,9 @@ public class SysJobController {
 	@HasPermission("job_sys_job_edit")
 	@Operation(description = "修改定时任务")
 	public R updateById(@RequestBody SysJob sysJob) {
+		if (!isRestTaskUrlAllowed(sysJob)) {
+			return R.failed("REST任务地址未配置白名单或不在白名单中");
+		}
 		sysJob.setUpdateBy(SecurityUtils.getUser().getUsername());
 		SysJob querySysJob = this.sysJobService.getById(sysJob.getJobId());
 		if (PigQuartzEnum.JOB_STATUS_NOT_RUNNING.getType().equals(querySysJob.getJobStatus())) {
@@ -320,6 +330,11 @@ public class SysJobController {
 	@Operation(description = "导出任务")
 	public List<SysJob> export(SysJob sysJob) {
 		return sysJobService.list(Wrappers.query(sysJob));
+	}
+
+	private boolean isRestTaskUrlAllowed(SysJob sysJob) {
+		return !JobTypeQuartzEnum.REST.getType().equals(sysJob.getJobType())
+				|| restTaskUrlValidator.isAllowed(sysJob.getExecutePath());
 	}
 
 }

--- a/pig-visual/pig-quartz/src/main/java/com/pig4cloud/pig/daemon/quartz/util/RestTaskInvok.java
+++ b/pig-visual/pig-quartz/src/main/java/com/pig4cloud/pig/daemon/quartz/util/RestTaskInvok.java
@@ -18,6 +18,7 @@
 package com.pig4cloud.pig.daemon.quartz.util;
 
 import cn.hutool.http.HttpRequest;
+import cn.hutool.http.HttpResponse;
 import cn.hutool.http.HttpUtil;
 import com.pig4cloud.pig.daemon.quartz.entity.SysJob;
 import com.pig4cloud.pig.daemon.quartz.exception.TaskException;
@@ -35,15 +36,25 @@ import org.springframework.stereotype.Component;
 @Component("restTaskInvok")
 public class RestTaskInvok implements ITaskInvok {
 
+	private final RestTaskUrlValidator restTaskUrlValidator;
+
 	@Override
 	public void invokMethod(SysJob sysJob) throws TaskException {
+		String executePath = sysJob.getExecutePath();
+		if (!restTaskUrlValidator.isAllowed(executePath)) {
+			log.warn("定时任务REST地址未通过白名单校验，任务ID：{}", sysJob.getJobId());
+			throw new TaskException("定时任务REST地址未通过白名单校验");
+		}
+
 		try {
-			HttpRequest request = HttpUtil.createGet(sysJob.getExecutePath());
-			request.execute();
+			HttpRequest request = HttpUtil.createGet(executePath).setMaxRedirectCount(0);
+			try (HttpResponse ignored = request.execute()) {
+				// REST 任务仅关注请求是否成功发出，响应内容无需保留
+			}
 		}
 		catch (Exception e) {
-			log.error("定时任务restTaskInvok异常,执行任务：{}", sysJob.getExecutePath());
-			throw new TaskException("定时任务restTaskInvok业务执行失败,任务：" + sysJob.getExecutePath());
+			log.error("定时任务restTaskInvok异常，任务ID：{}", sysJob.getJobId(), e);
+			throw new TaskException("定时任务restTaskInvok业务执行失败，任务ID：" + sysJob.getJobId());
 		}
 	}
 

--- a/pig-visual/pig-quartz/src/main/java/com/pig4cloud/pig/daemon/quartz/util/RestTaskUrlValidator.java
+++ b/pig-visual/pig-quartz/src/main/java/com/pig4cloud/pig/daemon/quartz/util/RestTaskUrlValidator.java
@@ -1,0 +1,99 @@
+/*
+ *    Copyright (c) 2018-2026, lengleng All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * Redistributions of source code must retain the above copyright notice,
+ * this list of conditions and the following disclaimer.
+ * Redistributions in binary form must reproduce the above copyright
+ * notice, this list of conditions and the following disclaimer in the
+ * documentation and/or other materials provided with the distribution.
+ * Neither the name of the pig4cloud.com developer nor the names of its
+ * contributors may be used to endorse or promote products derived from
+ * this software without specific prior written permission.
+ * Author: lengleng (wangiegie@gmail.com)
+ */
+
+package com.pig4cloud.pig.daemon.quartz.util;
+
+import cn.hutool.core.collection.CollUtil;
+import cn.hutool.core.util.StrUtil;
+import cn.hutool.core.util.URLUtil;
+import com.pig4cloud.pig.daemon.quartz.config.QuartzProtectionProperties;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.util.Locale;
+import java.util.Set;
+
+/**
+ * REST 定时任务 URL 白名单校验器。
+ */
+@Component
+@RequiredArgsConstructor
+public class RestTaskUrlValidator {
+
+	private static final Set<String> ALLOWED_SCHEMES = Set.of("http", "https");
+
+	private final QuartzProtectionProperties properties;
+
+	/**
+	 * 校验任务地址是否命中 URL 源白名单。
+	 * @param executePath REST 任务地址
+	 * @return 是否允许请求
+	 */
+	public boolean isAllowed(String executePath) {
+		URI target = parseHttpUri(executePath, false);
+		if (target == null || CollUtil.isEmpty(properties.getRestTaskUrlWhitelist())) {
+			return false;
+		}
+
+		return properties.getRestTaskUrlWhitelist()
+			.stream()
+			.map(item -> parseHttpUri(item, true))
+			.anyMatch(allowed -> sameOrigin(target, allowed));
+	}
+
+	private URI parseHttpUri(String value, boolean originOnly) {
+		if (StrUtil.isBlank(value)) {
+			return null;
+		}
+
+		try {
+			URI uri = URLUtil.toURI(value).normalize();
+			String scheme = uri.getScheme();
+			if (StrUtil.isBlank(scheme) || !ALLOWED_SCHEMES.contains(scheme.toLowerCase(Locale.ROOT))
+					|| StrUtil.isBlank(uri.getHost()) || uri.getUserInfo() != null) {
+				return null;
+			}
+			if (originOnly && (StrUtil.isNotBlank(uri.getQuery()) || StrUtil.isNotBlank(uri.getFragment())
+					|| !(StrUtil.isBlank(uri.getPath()) || StrUtil.equals(uri.getPath(), "/")))) {
+				return null;
+			}
+			return uri;
+		}
+		catch (RuntimeException ex) {
+			return null;
+		}
+	}
+
+	private boolean sameOrigin(URI target, URI allowed) {
+		return allowed != null && target.getScheme().equalsIgnoreCase(allowed.getScheme())
+				&& normalizeHost(target.getHost()).equals(normalizeHost(allowed.getHost()))
+				&& effectivePort(target) == effectivePort(allowed);
+	}
+
+	private String normalizeHost(String host) {
+		return host.toLowerCase(Locale.ROOT);
+	}
+
+	private int effectivePort(URI uri) {
+		if (uri.getPort() >= 0) {
+			return uri.getPort();
+		}
+		return "https".equalsIgnoreCase(uri.getScheme()) ? 443 : 80;
+	}
+
+}

--- a/pig-visual/pig-quartz/src/test/java/com/pig4cloud/pig/daemon/quartz/controller/SysJobControllerTests.java
+++ b/pig-visual/pig-quartz/src/test/java/com/pig4cloud/pig/daemon/quartz/controller/SysJobControllerTests.java
@@ -1,0 +1,65 @@
+package com.pig4cloud.pig.daemon.quartz.controller;
+
+import com.pig4cloud.pig.common.core.util.R;
+import com.pig4cloud.pig.daemon.quartz.constants.JobTypeQuartzEnum;
+import com.pig4cloud.pig.daemon.quartz.entity.SysJob;
+import com.pig4cloud.pig.daemon.quartz.service.SysJobLogService;
+import com.pig4cloud.pig.daemon.quartz.service.SysJobService;
+import com.pig4cloud.pig.daemon.quartz.util.RestTaskUrlValidator;
+import com.pig4cloud.pig.daemon.quartz.util.TaskUtil;
+import org.junit.jupiter.api.Test;
+import org.quartz.Scheduler;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class SysJobControllerTests {
+
+	private final SysJobService sysJobService = mock(SysJobService.class);
+
+	private final SysJobLogService sysJobLogService = mock(SysJobLogService.class);
+
+	private final TaskUtil taskUtil = mock(TaskUtil.class);
+
+	private final Scheduler scheduler = mock(Scheduler.class);
+
+	private final RestTaskUrlValidator validator = mock(RestTaskUrlValidator.class);
+
+	private final SysJobController controller = new SysJobController(sysJobService, sysJobLogService, taskUtil,
+			scheduler, validator);
+
+	@Test
+	void rejectsRestTaskBeforeSaving() {
+		SysJob sysJob = restJob();
+		when(validator.isAllowed(sysJob.getExecutePath())).thenReturn(false);
+
+		R result = controller.save(sysJob);
+
+		assertThat(result.isOk()).isFalse();
+		assertThat(result.getMsg()).isEqualTo("REST任务地址未配置白名单或不在白名单中");
+		verifyNoInteractions(taskUtil, sysJobService, scheduler);
+	}
+
+	@Test
+	void rejectsRestTaskBeforeUpdating() {
+		SysJob sysJob = restJob();
+		when(validator.isAllowed(sysJob.getExecutePath())).thenReturn(false);
+
+		R result = controller.updateById(sysJob);
+
+		assertThat(result.isOk()).isFalse();
+		assertThat(result.getMsg()).isEqualTo("REST任务地址未配置白名单或不在白名单中");
+		verifyNoInteractions(taskUtil, sysJobService, scheduler);
+	}
+
+	private SysJob restJob() {
+		return SysJob.builder()
+			.jobId(1L)
+			.jobType(JobTypeQuartzEnum.REST.getType())
+			.executePath("http://127.0.0.1/internal")
+			.build();
+	}
+
+}

--- a/pig-visual/pig-quartz/src/test/java/com/pig4cloud/pig/daemon/quartz/util/RestTaskInvokTests.java
+++ b/pig-visual/pig-quartz/src/test/java/com/pig4cloud/pig/daemon/quartz/util/RestTaskInvokTests.java
@@ -1,0 +1,70 @@
+package com.pig4cloud.pig.daemon.quartz.util;
+
+import com.pig4cloud.pig.daemon.quartz.entity.SysJob;
+import com.pig4cloud.pig.daemon.quartz.exception.TaskException;
+import com.sun.net.httpserver.HttpServer;
+import org.junit.jupiter.api.Test;
+
+import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class RestTaskInvokTests {
+
+	private final RestTaskUrlValidator validator = mock(RestTaskUrlValidator.class);
+
+	private final RestTaskInvok invoker = new RestTaskInvok(validator);
+
+	@Test
+	void rejectsUrlBeforeSendingRequest() {
+		SysJob sysJob = SysJob.builder().jobId(1L).executePath("http://127.0.0.1/internal").build();
+		when(validator.isAllowed(sysJob.getExecutePath())).thenReturn(false);
+
+		assertThatThrownBy(() -> invoker.invokMethod(sysJob)).isInstanceOf(TaskException.class)
+			.hasMessage("定时任务REST地址未通过白名单校验");
+		verify(validator).isAllowed(sysJob.getExecutePath());
+	}
+
+	@Test
+	void doesNotFollowRedirects() throws Exception {
+		AtomicInteger redirectHits = new AtomicInteger();
+		AtomicInteger targetHits = new AtomicInteger();
+		HttpServer targetServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+		targetServer.createContext("/target", exchange -> {
+			targetHits.incrementAndGet();
+			exchange.sendResponseHeaders(200, -1);
+			exchange.close();
+		});
+		HttpServer redirectServer = HttpServer.create(new InetSocketAddress("127.0.0.1", 0), 0);
+		redirectServer.createContext("/redirect", exchange -> {
+			redirectHits.incrementAndGet();
+			exchange.getResponseHeaders()
+				.add("Location", "http://127.0.0.1:" + targetServer.getAddress().getPort() + "/target");
+			exchange.sendResponseHeaders(302, -1);
+			exchange.close();
+		});
+
+		targetServer.start();
+		redirectServer.start();
+		try {
+			String executePath = "http://127.0.0.1:" + redirectServer.getAddress().getPort() + "/redirect";
+			SysJob sysJob = SysJob.builder().jobId(2L).executePath(executePath).build();
+			when(validator.isAllowed(executePath)).thenReturn(true);
+
+			invoker.invokMethod(sysJob);
+
+			assertThat(redirectHits).hasValue(1);
+			assertThat(targetHits).hasValue(0);
+		}
+		finally {
+			redirectServer.stop(0);
+			targetServer.stop(0);
+		}
+	}
+
+}

--- a/pig-visual/pig-quartz/src/test/java/com/pig4cloud/pig/daemon/quartz/util/RestTaskUrlValidatorTests.java
+++ b/pig-visual/pig-quartz/src/test/java/com/pig4cloud/pig/daemon/quartz/util/RestTaskUrlValidatorTests.java
@@ -1,0 +1,65 @@
+package com.pig4cloud.pig.daemon.quartz.util;
+
+import com.pig4cloud.pig.daemon.quartz.config.QuartzProtectionProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class RestTaskUrlValidatorTests {
+
+	private QuartzProtectionProperties properties;
+
+	private RestTaskUrlValidator validator;
+
+	@BeforeEach
+	void setUp() {
+		properties = new QuartzProtectionProperties();
+		validator = new RestTaskUrlValidator(properties);
+	}
+
+	@Test
+	void rejectsAllUrlsWhenWhitelistIsEmpty() {
+		assertThat(validator.isAllowed("https://api.example.com/jobs")).isFalse();
+	}
+
+	@Test
+	void acceptsPathAndQueryForWhitelistedOrigin() {
+		properties.setRestTaskUrlWhitelist(Set.of("https://api.example.com"));
+
+		assertThat(validator.isAllowed("https://api.example.com/jobs/run?id=1")).isTrue();
+	}
+
+	@Test
+	void normalizesHostCaseAndDefaultPort() {
+		properties.setRestTaskUrlWhitelist(Set.of("https://API.EXAMPLE.COM:443"));
+
+		assertThat(validator.isAllowed("https://api.example.com/jobs")).isTrue();
+	}
+
+	@Test
+	void rejectsPrefixAndUserInfoBypasses() {
+		properties.setRestTaskUrlWhitelist(Set.of("http://www.baidu.com"));
+
+		assertThat(validator.isAllowed("http://www.baidu.com.evil.example/internal")).isFalse();
+		assertThat(validator.isAllowed("http://www.baidu.com@127.0.0.1/internal")).isFalse();
+	}
+
+	@Test
+	void rejectsDifferentSchemeOrPort() {
+		properties.setRestTaskUrlWhitelist(Set.of("https://api.example.com"));
+
+		assertThat(validator.isAllowed("http://api.example.com/jobs")).isFalse();
+		assertThat(validator.isAllowed("https://api.example.com:8443/jobs")).isFalse();
+	}
+
+	@Test
+	void ignoresInvalidWhitelistEntries() {
+		properties.setRestTaskUrlWhitelist(Set.of("https://api.example.com/private", "file:///tmp/task"));
+
+		assertThat(validator.isAllowed("https://api.example.com/private")).isFalse();
+	}
+
+}


### PR DESCRIPTION
## 改了什么

- 新增 `pig.quartz.protection.rest-task-url-whitelist` 配置，按协议、主机和有效端口精确匹配允许访问的 URL 源。
- 使用 Hutool `URLUtil` 解析 HTTP/HTTPS 地址，拒绝空白名单、非法协议、用户信息和不合规的白名单项。
- 在 REST 任务新增、修改以及实际执行前统一校验 `executePath`。
- REST 请求禁用重定向并及时关闭响应，避免通过白名单地址跳转到非预期目标。
- 增加 URL 匹配、入口拦截和重定向行为测试。

## 为什么改

Quartz REST 任务此前直接请求用户可控的 `executePath`，没有限制出站目标，可能被利用访问非预期地址。此次改动采用显式 URL 源白名单，并在保存和执行两个阶段校验，避免存量数据或其他写入路径绕过限制。

Closes #1272

## 影响

- 白名单默认为空，升级后 REST 任务在未配置允许来源时会被拒绝。
- 白名单项格式为 `scheme://host[:port]`；任务地址仍可携带路径和查询参数。
- 非 REST 类型的 Quartz 任务不受影响。

## 验证

- `mvn -pl pig-visual/pig-quartz -am -DskipTests compile`
- `mvn -pl pig-visual/pig-quartz -Dtest=RestTaskUrlValidatorTests,SysJobControllerTests,RestTaskInvokTests test`（10 个测试通过）
- `mvn -pl pig-visual/pig-quartz spring-javaformat:validate`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable URL whitelisting for REST-based scheduled tasks.
  * REST task URLs are validated by scheme, host, and port, while paths and query parameters remain supported.
  * HTTP redirects are no longer followed during REST task execution.

* **Bug Fixes**
  * Invalid or unauthorized REST task URLs are rejected during creation, updates, and execution.
  * Improved error handling and resource cleanup for REST requests.

* **Tests**
  * Added coverage for URL validation, authorization failures, normalization, and redirect prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->