### PR TITLE
fix(upms): 修复个人信息修改时短信验证码已过期导致的空指针异常

### DIFF
--- a/pig-upms/pig-upms-biz/src/main/java/com/pig4cloud/pig/admin/service/impl/SysUserServiceImpl.java
+++ b/pig-upms/pig-upms-biz/src/main/java/com/pig4cloud/pig/admin/service/impl/SysUserServiceImpl.java
@@ -20,6 +20,7 @@
 package com.pig4cloud.pig.admin.service.impl;
 
 import cn.hutool.core.collection.CollUtil;
+import cn.hutool.core.convert.Convert;
 import cn.hutool.core.util.StrUtil;
 import com.baomidou.mybatisplus.core.conditions.update.LambdaUpdateWrapper;
 import com.baomidou.mybatisplus.core.metadata.IPage;
@@ -255,7 +256,8 @@ public class SysUserServiceImpl extends ServiceImpl<SysUserMapper, SysUser> impl
 		if (StrUtil.isNotBlank(userDto.getPhone())) {
 			Object codeObj = RedisUtils.get(
 					CacheConstants.DEFAULT_CODE_KEY + LoginTypeEnum.SMS.getType() + StringPool.AT + userDto.getPhone());
-			if (!StrUtil.equals(userDto.getCode(), codeObj.toString())) {
+			// 验证码可能已过期或未发送（Redis 中不存在），codeObj 为 null 时直接判为校验失败，避免 NPE
+			if (!StrUtil.equals(userDto.getCode(), Convert.toStr(codeObj))) {
 				return R.failed(MsgUtils.getMessage(UpmsErrorCodes.SYS_APP_SMS_ERROR));
 			}
 			sysUser.setPhone(userDto.getPhone());


### PR DESCRIPTION
### 问题

`SysUserServiceImpl#updateUserInfo`（`/user/personal/edit` 接口）中 `RedisUtils.get(...)` 在验证码已过期或未发送时返回 null，`codeObj.toString()` 直接 NPE 返回 500 而非业务错误提示。同文件 `registerUser`、`forgetUserPassword` 均使用 null 安全的 `StrUtil.equals(codeObj, code)` 写法，唯独此处不安全。

### 修复

改为 `StrUtil.equals(userDto.getCode(), Convert.toStr(codeObj))`，过期时正常返回验证码错误。

位置：`pig-upms/pig-upms-biz/.../SysUserServiceImpl.java`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SMS verification when verification data is missing or unavailable.
  * Prevented errors during user information updates while preserving verification failure behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->