### PR TITLE
perf(upms): 消除用户导入/部门导出循环内重复全表查询（N+1）

### DIFF
--- a/pig-upms/pig-upms-biz/src/main/java/com/pig4cloud/pig/admin/service/impl/SysDeptServiceImpl.java
+++ b/pig-upms/pig-upms-biz/src/main/java/com/pig4cloud/pig/admin/service/impl/SysDeptServiceImpl.java
@@ -134,15 +134,14 @@ public class SysDeptServiceImpl extends ServiceImpl<SysDeptMapper, SysDept> impl
 	@Override
 	public List<DeptExcelVO> listExcelVo() {
 		List<SysDept> list = this.list();
+		// 一次性构建 deptId -> name 映射，避免每个部门都触发一次全表查询（N+1）
+		Map<Long, String> deptIdNameMap = new HashMap<>(list.size());
+		list.forEach(it -> deptIdNameMap.put(it.getDeptId(), it.getName()));
 		List<DeptExcelVO> deptExcelVos = list.stream().map(item -> {
 			DeptExcelVO deptExcelVo = new DeptExcelVO();
 			deptExcelVo.setName(item.getName());
-			Optional<String> first = this.list()
-				.stream()
-				.filter(it -> item.getParentId().equals(it.getDeptId()))
-				.map(SysDept::getName)
-				.findFirst();
-			deptExcelVo.setParentName(first.orElse("根部门"));
+			String parentName = deptIdNameMap.get(item.getParentId());
+			deptExcelVo.setParentName(parentName == null ? "根部门" : parentName);
 			deptExcelVo.setSortOrder(item.getSortOrder());
 			return deptExcelVo;
 		}).toList();

--- a/pig-upms/pig-upms-biz/src/main/java/com/pig4cloud/pig/admin/service/impl/SysUserServiceImpl.java
+++ b/pig-upms/pig-upms-biz/src/main/java/com/pig4cloud/pig/admin/service/impl/SysUserServiceImpl.java
@@ -413,22 +413,21 @@ public class SysUserServiceImpl extends ServiceImpl<SysUserMapper, SysUser> impl
 		List<SysDept> deptList = sysDeptService.list();
 		List<SysRole> roleList = sysRoleService.list();
 		List<SysPost> postList = sysPostService.list();
-		// 个性化校验逻辑：一次性查询现有用户，避免每行 Excel 都全表查询（N+1）
-		List<SysUser> userList = this.list();
 
 		// 执行数据插入操作 组装 UserDto
 		for (UserExcelVO excel : excelVOList) {
 			Set<String> errorMsg = new HashSet<>();
-			// 校验用户名是否存在
-			boolean exsitUserName = userList.stream()
-				.anyMatch(sysUser -> excel.getUsername().equals(sysUser.getUsername()));
+			// 校验用户名是否存在（按用户名点查代替全表查询，既能观察到本文件已插入的行，也能观察到并发请求已提交的数据）
+			boolean exsitUserName = this.count(
+					Wrappers.<SysUser>lambdaQuery().eq(SysUser::getUsername, excel.getUsername())) > 0;
 
 			if (exsitUserName) {
 				errorMsg.add(MsgUtils.getMessage(UpmsErrorCodes.SYS_USER_USERNAME_EXISTING, excel.getUsername()));
 			}
 
 			// 校验手机号是否存在
-			boolean exsitPhone = userList.stream().anyMatch(sysUser -> excel.getPhone().equals(sysUser.getPhone()));
+			boolean exsitPhone = this.count(
+					Wrappers.<SysUser>lambdaQuery().eq(SysUser::getPhone, excel.getPhone())) > 0;
 			if (exsitPhone) {
 				errorMsg.add(MsgUtils.getMessage(UpmsErrorCodes.SYS_USER_PHONE_EXISTING, excel.getPhone()));
 			}
@@ -467,11 +466,6 @@ public class SysUserServiceImpl extends ServiceImpl<SysUserMapper, SysUser> impl
 			// 数据合法情况
 			if (CollUtil.isEmpty(errorMsg)) {
 				insertExcelUser(excel, deptOptional, roleCollList, postCollList);
-				// 将本行新增用户纳入查重范围，保持与“每行重新查询”一致的文件内去重语义
-				SysUser inserted = new SysUser();
-				inserted.setUsername(excel.getUsername());
-				inserted.setPhone(excel.getPhone());
-				userList.add(inserted);
 			}
 			else {
 				// 数据不合法情况

--- a/pig-upms/pig-upms-biz/src/main/java/com/pig4cloud/pig/admin/service/impl/SysUserServiceImpl.java
+++ b/pig-upms/pig-upms-biz/src/main/java/com/pig4cloud/pig/admin/service/impl/SysUserServiceImpl.java
@@ -413,12 +413,11 @@ public class SysUserServiceImpl extends ServiceImpl<SysUserMapper, SysUser> impl
 		List<SysDept> deptList = sysDeptService.list();
 		List<SysRole> roleList = sysRoleService.list();
 		List<SysPost> postList = sysPostService.list();
+		// 个性化校验逻辑：一次性查询现有用户，避免每行 Excel 都全表查询（N+1）
+		List<SysUser> userList = this.list();
 
 		// 执行数据插入操作 组装 UserDto
 		for (UserExcelVO excel : excelVOList) {
-			// 个性化校验逻辑
-			List<SysUser> userList = this.list();
-
 			Set<String> errorMsg = new HashSet<>();
 			// 校验用户名是否存在
 			boolean exsitUserName = userList.stream()
@@ -468,6 +467,11 @@ public class SysUserServiceImpl extends ServiceImpl<SysUserMapper, SysUser> impl
 			// 数据合法情况
 			if (CollUtil.isEmpty(errorMsg)) {
 				insertExcelUser(excel, deptOptional, roleCollList, postCollList);
+				// 将本行新增用户纳入查重范围，保持与“每行重新查询”一致的文件内去重语义
+				SysUser inserted = new SysUser();
+				inserted.setUsername(excel.getUsername());
+				inserted.setPhone(excel.getPhone());
+				userList.add(inserted);
 			}
 			else {
 				// 数据不合法情况


### PR DESCRIPTION
### 问题

1. `importUser`：每导入一行 Excel 执行一次 `this.list()` 全表 `SELECT * FROM sys_user`；
2. `listExcelVo`：导出时每个部门执行一次全表 `sys_dept` 查询来取父部门名称。用户/部门量稍大时导入导出明显变慢并冲击数据库。

### 修复

1. 用户全表查询提到循环外；插入成功后将新用户（用户名/手机号）加入查重列表，保持与原"每行重查"一致的文件内去重语义；
2. 导出改为一次性构建 `deptId -> name` 映射，O(n) 查找。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved department and user data imports by reducing repeated database lookups.
  * Preserved parent department name resolution, including the default “根部门” label.
  * Enhanced duplicate-user detection within the same import file.
  * Improved handling of duplicate usernames and phone numbers during imports, including records added concurrently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->