### PR TITLE
fix(upms): 修复组织树接口 parentDeptId 未传时自动拆箱空指针异常

### DIFF
--- a/pig-upms/pig-upms-biz/src/main/java/com/pig4cloud/pig/admin/service/impl/SysDeptServiceImpl.java
+++ b/pig-upms/pig-upms-biz/src/main/java/com/pig4cloud/pig/admin/service/impl/SysDeptServiceImpl.java
@@ -276,7 +276,8 @@ public class SysDeptServiceImpl extends ServiceImpl<SysDeptMapper, SysDept> impl
 		});
 		dict.set("childDepartments", deptVoList);
 
-		if (!StrUtil.equals(type, OrgTypeEnum.DEPT.getType())) {
+		// parentDeptId 可为空（首次加载组织树不传参），为空时无需查询部门下的员工
+		if (!StrUtil.equals(type, OrgTypeEnum.DEPT.getType()) && Objects.nonNull(parentDeptId)) {
 
 			List<OrgTreeVO> userVoList = new ArrayList<>();
 
@@ -299,7 +300,7 @@ public class SysDeptServiceImpl extends ServiceImpl<SysDeptMapper, SysDept> impl
 			dict.set("employees", userVoList);
 		}
 
-		if (parentDeptId > 0) {
+		if (Objects.nonNull(parentDeptId) && parentDeptId > 0) {
 			List<SysDept> allDept = this.list();
 			List<SysDept> depts = DataUtil.selectParentByDept(parentDeptId, allDept);
 			dict.set("titleDepartments", CollUtil.reverse(depts));


### PR DESCRIPTION
### 问题

`GET /dept/org` 的 `parentDeptId` 为可选参数（首次加载组织树不传）。`SysDeptServiceImpl#listOrgTree` 中：

1. `parentDeptId > 0`（:302）对 null 自动拆箱直接 NPE——同方法 :264 已有 `Objects.nonNull` 防护，此处遗漏；
2. 用户 join 查询 `.eq(SysUserDept::getDeptId, parentDeptId)`（:286）在 null 时生成非法条件。

### 修复

员工查询块增加 `Objects.nonNull(parentDeptId)` 前置条件；`parentDeptId > 0` 改为 `Objects.nonNull(parentDeptId) && parentDeptId > 0`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved department tree handling when no parent department is specified.
  * Prevented unnecessary employee lookups for department-only requests.
  * Fixed title-department searches to avoid invalid null comparisons.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->